### PR TITLE
Fixes build issues on OpenBSD

### DIFF
--- a/cde/admin/IntegTools/post_install/openbsd/Imakefile
+++ b/cde/admin/IntegTools/post_install/openbsd/Imakefile
@@ -34,23 +34,19 @@ BUILD_UDB_LIST = $(SHELL) ../build_udb_list
 all::
 
 configMin:: $(DATABASE_DIR)/CDE-MIN.udb
-	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) \
-            $(DATABASE_DIR)/CDE-MIN.udb > CDE-MIN.lst
+	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) $(DATABASE_DIR)/CDE-MIN.udb > CDE-MIN.lst
 	$(BUILD_UDB_LIST) CDE-MIN ../../../..
 
 configTT:: $(DATABASE_DIR)/CDE-TT.udb
-	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) \
-            $(DATABASE_DIR)/CDE-TT.udb > CDE-TT.lst
+	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) $(DATABASE_DIR)/CDE-TT.udb > CDE-TT.lst
 	$(BUILD_UDB_LIST) CDE-TT ../../../..
 
 configRun:: $(DATABASE_DIR)/CDE-RUN.udb
-	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) \
-            $(DATABASE_DIR)/CDE-RUN.udb > CDE-RUN.lst
+	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) $(DATABASE_DIR)/CDE-RUN.udb > CDE-RUN.lst
 	$(BUILD_UDB_LIST) CDE-RUN ../../../..
 
 configShlibs:: $(DATABASE_DIR)/CDE-SHLIBS.udb
-	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) \
-            $(DATABASE_DIR)/CDE-SHLIBS.udb > CDE-SHLIBS.lst
+	$(UDBTOANY) -toLst -ReleaseStream $(PLATFORM) $(DATABASE_DIR)/CDE-SHLIBS.udb > CDE-SHLIBS.lst
 	$(BUILD_UDB_LIST) CDE-SHLIBS ../../../..
 
 LOCAL_CPP_DEFINES = -DCDE_INSTALLATION_TOP=$(CDE_INSTALLATION_TOP) \

--- a/cde/config/cf/OpenBSD.cf
+++ b/cde/config/cf/OpenBSD.cf
@@ -176,9 +176,14 @@ XCOMM operating system:  OSName (OSMajorVersion./**/OSMinorVersion./**/OSTeenyVe
 #define PreProcessCmd   	CppCmd
 #define PreIncDir		DefaultGccIncludeDir
 
-#ifndef CcCmd
-#define CcCmd 			cc
+#if OSMajorVersion > 6 || (OSMajorVersion == 6 && OSMinorVersion >= 2)
+#define CcCmd			clang
+#define CplusplusCmd		clang++
+#else
+#define CcCmd			gcc
+#define CplusplusCmd		g++
 #endif
+
 #ifndef AsCmd
 #define AsCmd			cc -c -x assembler
 #endif

--- a/cde/programs/dtksh/ksh93/src/cmd/ksh93/feature/poll
+++ b/cde/programs/dtksh/ksh93/src/cmd/ksh93/feature/poll
@@ -27,8 +27,5 @@ cat{
 	#   ifndef FD_SET
 	#	define FD_SET(n,x)	(*(x)|=(1L<<(n)))
 	#   endif /* FD_SET */
-	#   ifndef _typ_fd_set
-		typedef long fd_set;
-	#   endif /*_typ_fd_set */
 	#endif /* _lib_select */
 }end

--- a/cde/programs/dtksh/ksh93/src/cmd/ksh93/features/poll
+++ b/cde/programs/dtksh/ksh93/src/cmd/ksh93/features/poll
@@ -27,8 +27,5 @@ cat{
 	#   ifndef FD_SET
 	#	define FD_SET(n,x)	(*(x)|=(1L<<(n)))
 	#   endif /* FD_SET */
-	#   ifndef _typ_fd_set
-		typedef long fd_set;
-	#   endif /*_typ_fd_set */
 	#endif /* _lib_select */
 }end

--- a/cde/programs/dtmail/libDtMail/Common/Session.C
+++ b/cde/programs/dtmail/libDtMail/Common/Session.C
@@ -1618,7 +1618,7 @@ char *from_cs, char *to_cs)
    DtMailEnv error;
    iconv_t cd;
    size_t ileft = (size_t) bp_len, oleft = (size_t) bp_len, ret = 0;
-#if defined(_AIX) || defined(sun) || defined(CSRG_BASED)
+#if defined(_AIX) || defined(sun)
    const char *ip = (const char *) *bp;
 #else
    char *ip = *bp;

--- a/cde/programs/dtmail/libDtMail/RFC/RFCBodyPart.C
+++ b/cde/programs/dtmail/libDtMail/RFC/RFCBodyPart.C
@@ -1030,7 +1030,7 @@ char *from_cs, char *to_cs)
    DtMailEnv error;
    iconv_t cd;
    size_t ileft = (size_t) bp_len, oleft = (size_t) bp_len, ret = 0;
-#if defined(_aix) || defined(sun) || defined(CSRG_BASED)
+#if defined(_aix) || defined(sun)
    const char *ip = (const char *) *bp;
 #else
    char *ip = *bp;


### PR DESCRIPTION
Fixes:

* use clang for OpenBSD 6.2
* imake space vs tab issue
*dtmail csrg exception
* ksh93 fd_set typedef issue

By: Pascal de Bruijn
From https://sourceforge.net/p/cdesktopenv/tickets/70/