### PR TITLE
Fixes stack smash exception

### DIFF
--- a/cde/programs/dtpad/optionsCB.c
+++ b/cde/programs/dtpad/optionsCB.c
@@ -72,9 +72,9 @@ OverstrikeCB(
 {
     Arg al[1];
     Editor *pPad = (Editor *)client_data;
-    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *) 
+    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *)
 				       call_data;
-				       
+
     XtSetArg(al[0], DtNoverstrike, (Boolean) cb->set);
     XtSetValues(pPad->editor, al, 1);
     pPad->xrdb.overstrike = (Boolean) cb->set;	/* reset edit session default */
@@ -99,12 +99,12 @@ WordWrapCB(
 {
     Arg al[1];
     Editor *pPad = (Editor *)client_data;
-    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *) 
+    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *)
 				       call_data;
     SaveAs *pSaveAs = &pPad->fileStuff.fileWidgets.saveAs;
     Select *pSelect = &pPad->fileStuff.fileWidgets.select;
 
-    XtSetArg(al[0], DtNwordWrap, (Boolean) cb->set);
+    XtSetArg(al[0], DtNwordWrap, (int) cb->set);
     XtSetValues(pPad->editor, al, 1);
 
     pPad->xrdb.wordWrap = (Boolean) cb->set;	/* reset edit session default */
@@ -148,13 +148,13 @@ StatusLineCB(
 {
     Arg al[1];
     Editor *pPad = (Editor *)client_data;
-    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *) 
+    XmToggleButtonCallbackStruct *cb = (XmToggleButtonCallbackStruct *)
 				       call_data;
-				       
+
     XtSetArg(al[0], DtNshowStatusLine, (Boolean) cb->set);
     XtSetValues(pPad->editor, al, 1);
     pPad->xrdb.statusLine = (Boolean) cb->set;	/* reset edit session default */
- 
+
     /* Reset the resize increment and minimum window size properties. */
     SetAppShellResizeHints(pPad);
 }


### PR DESCRIPTION
`XmToggleButtonCallbackStruct#set` was a bool in Motif 1.2, but is an int in Motif > v2

See: http://www.motifdeveloper.com/tips/tip19.html 

```
#0  thrkill () at -:3
#1  0x00000a97c01cc1fb in _libc___stack_smash_handler (func=Variable "func" is not available.
) at /usr/src/lib/libc/sys/stack_protector.c:79
#2  0x00000a97cf6170f7 in Scan (source=Variable "source" is not available.
) at ctype.h:157
#3  0x00000a97cf6071d3 in _XmTextFindLineEnd (tw=0xa97f9a2f000, position=Variable "position" is not available.
) at TextOut.c:1357
#4  0x00000a97cf5f6309 in _XmTextRealignLineTable (tw=0xa97f9a2f000, temp_table=0x0, temp_table_size=0x0, cur_index=Variable "cur_index" is not available.
) at Text.c:1308
#5  0x00000a97cf60fa67 in OutputSetValues (oldw=0x7f7ffffbccd0, reqw=Variable "reqw" is not available.
) at TextOut.c:4595
#6  0x00000a97cf5f5d6e in SetValues (oldw=Variable "oldw" is not available.
) at Text.c:2735
#7  0x00000a9788455522 in CallSetValues () from /usr/X11R6/lib/libXt.so.11.0
#8  0x00000a978845541f in XtSetValues () from /usr/X11R6/lib/libXt.so.11.0
#9  0x00000a974d7cd28c in SetValues (cw=0xa97640da000, rw=0xa974a5c0800, nw=0xa97ad988800) at Editor.c:2491
#10 0x00000a9788455522 in CallSetValues () from /usr/X11R6/lib/libXt.so.11.0
#11 0x00000a978845541f in XtSetValues () from /usr/X11R6/lib/libXt.so.11.0
#12 0x00000a952c5119e2 in WordWrapCB (w=0xa978ba40800, client_data=0xa97b61b1680 "B???\177\177", call_data=0x7f7ffffbdb88 "\002") at optionsCB.c:108
```